### PR TITLE
Fix output and default setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ plugins:
     # - ETA : The date and time formatted in "%H:%M:%S Day %d" that the print is estimated to be completed
     # - filepos: The current position in the file currently being printed
     messages:
-      - "{completion:.2f}% complete"
+      - "{completion:.2f}%% complete"
       - "ETL: {printTimeLeft}"
       - "ETA: {ETA}"
 ```

--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -100,12 +100,12 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 	def get_settings_defaults(self):
 		return dict(
 			messages = [
-				"{completion:.2f}p  complete",
+				"{completion:.2f}%% complete",
 				"ETL {printTimeLeft}",
 				"ETA {ETA}"
 			],
-			eta_strftime = "%H %M %S Day %d",
-			etl_format = "{hours:02d}h{minutes:02d}m{seconds:02d}s",
+			eta_strftime = "%H:%M:%S Day %d",
+			etl_format = "{hours:02d}:{minutes:02d}:{seconds:02d}",
 			time_to_change = 10
 		)
 


### PR DESCRIPTION
Now the percentage output shows percent "%" and not "p" and the default configuration matches the one in the README.md.

This is only for the documentation and the default configuration.

If already installed you need to change the config on your own.