### PR TITLE
Add accuracy level to messages

### DIFF
--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -59,6 +59,22 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 
 		currentData["progress"]["printTimeLeftString"] = "No ETL yet"
 		currentData["progress"]["ETA"] = "No ETA yet"
+		accuracy = currentData["progress"]["printTimeLeftOrigin"]
+		if accuracy:
+			if accuracy == "estimate":
+				accuracy = "Best"
+			elif accuracy == "average":
+				accuracy = "Good"
+			elif accuracy == "analysis" or accuracy.startswith("mixed"):
+				accuracy = "Medium"
+			elif accuracy == "linear":
+				accuracy = "Bad"
+			else:
+				accuracy = "ERR"
+				self._logger.debug("Caught unmapped accuracy value: {0}".format(accuracy))
+		else:
+			accuracy = "N/A"
+		currentData["progress"]["accuracy"] = accuracy
 
 		#Add additional data
 		try:
@@ -78,7 +94,8 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 			completion = currentData["progress"]["completion"],
 			printTimeLeft = currentData["progress"]["printTimeLeftString"],
 			ETA = currentData["progress"]["ETA"],
-			filepos = currentData["progress"]["filepos"]
+			filepos = currentData["progress"]["filepos"],
+			accuracy = currentData["progress"]["accuracy"],
 		)
 
 	def _get_time_from_seconds(self, seconds):
@@ -102,7 +119,8 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 			messages = [
 				"{completion:.2f}p  complete",
 				"ETL {printTimeLeft}",
-				"ETA {ETA}"
+				"ETA {ETA}",
+				"{accuracy} accuracy"
 			],
 			eta_strftime = "%H %M %S Day %d",
 			etl_format = "{hours:02d}h{minutes:02d}m{seconds:02d}s",


### PR DESCRIPTION
This PR adds another message to the rotation, showing the accuracy of OctoPrint's time estimations in simple terms:

```
{accuracy} accuracy
```

In which `{accuracy}` becomes one of the following **Display Value**s.

OctoPrint value | Display Value | Meaning
--- | --- | ---
_estimate_ | **Best** | Best combination of following methods.
_average_ | **Good** | Estimate based on previous runs of the same GCode file.
_analysis_ | **Medium** | Estimate based on advanced GCode analysis, but that does not include machine's firmware settings (such as acceleration).
_mixed-*_ | **Medium** | A mix of different accuracies, reported by OctoPrint as _"medium accuracy"_.
_linear_ | **Bad** | Inaccurate estimate based solely on GCode's content and not including complex factors such as acceleration of smaller layers.
_-_ | **N/A** | No estimate currently available at all.
_???_ | **ERR** | An unmapped value has been found and will be logged _(future-proofing for new OctoPrint releases?)_.
