### PR TITLE
Added M73 and M73 specific for Prusa support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A plugin that sends M117 (and optionally M73) commands to the printer to display
 ![Example ETA](https://i.imgur.com/ocBp152.jpg)
 ![Example ETL](https://i.imgur.com/oJiMm2p.jpg)
 ![Example Percent](https://i.imgur.com/McaCNsx.jpg)
+![Example M73 Prusa](https://i.imgur.com/C1zeANH.jpg)
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OctoPrint-DetailedProgress
 
-A plugin that sends M117 commands to the printer to display the progress of the print job being currently streamed. The message to display can be configured (some placeholders included).
+A plugin that sends M117 (and optionally M73) commands to the printer to display the progress of the print job being currently streamed. The message to display can be configured (some placeholders included).
 ![Example ETA](https://i.imgur.com/ocBp152.jpg)
 ![Example ETL](https://i.imgur.com/oJiMm2p.jpg)
 ![Example Percent](https://i.imgur.com/McaCNsx.jpg)
@@ -21,6 +21,10 @@ plugins:
     time_to_change: 10
     eta_strftime: "%H:%M:%S Day %d"
     etl_format: "{hours:02d}:{minutes:02d}:{seconds:02d}"
+    # Send M73 progress commands 
+    use_M73: true
+    # M73 commands syntax specific for Prusa Firmware (>3.3.1)
+    M73_PrusaStyle: true
     # Messages to display. Placeholders:
     # - completion : The % completed
     # - printTimeLeft : A string in the format "HH:MM:SS" with how long the print still has left

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ plugins:
     etl_format: "{hours:02d}:{minutes:02d}:{seconds:02d}"
     # Send M73 progress commands 
     use_M73: true
-    # M73 commands syntax specific for Prusa Firmware (>3.3.1)
+    # M73 commands syntax specific for Prusa Firmware (>=3.3.0)
     M73_PrusaStyle: true
     # Messages to display. Placeholders:
     # - completion : The % completed

--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -48,8 +48,9 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 			self._printer.commands("M117 {}".format(message))
 			if use_M73:
 				if M73_PrusaStyle:
-					self._printer.commands("M73 P{}".format(currentData["progress"]["completion"]))
-					self._printer.commands("M73 Q{}".format(currentData["progress"]["completion"]))
+					printMinutesLeft = int(currentData["progress"]["printTimeLeft"]/60)
+					self._printer.commands("M73 P{}".format(currentData["progress"]["completion"],printMinutesLeft))
+					self._printer.commands("M73 Q{}".format(currentData["progress"]["completion"],printMinutesLeft))
 				else:
 					self._printer.commands("M73 P{}".format(currentData["progress"]["completion"]))
 				

--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -46,6 +46,13 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 
 			message = self._get_next_message(currentData)
 			self._printer.commands("M117 {}".format(message))
+			if use_M73:
+				if M73_PrusaStyle:
+					self._printer.commands("M73 P{}".format(currentData["progress"]["completion"]))
+					self._printer.commands("M73 Q{}".format(currentData["progress"]["completion"]))
+				else:
+					self._printer.commands("M73 P{}".format(currentData["progress"]["completion"]))
+				
 		except Exception as e:
 			self._logger.info("Caught an exception {0}\nTraceback:{1}".format(e,traceback.format_exc()))
 
@@ -124,7 +131,9 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 			],
 			eta_strftime = "%H %M %S Day %d",
 			etl_format = "{hours:02d}h{minutes:02d}m{seconds:02d}s",
-			time_to_change = 10
+			time_to_change = 10,
+			use_M73 = false,
+			M73_PrusaStyle = false
 		)
 
 	##~~ Softwareupdate hook

--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -133,8 +133,8 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 			eta_strftime = "%H %M %S Day %d",
 			etl_format = "{hours:02d}h{minutes:02d}m{seconds:02d}s",
 			time_to_change = 10,
-			use_M73 = false,
-			M73_PrusaStyle = false
+			use_M73 = False,
+			M73_PrusaStyle = False
 		)
 
 	##~~ Softwareupdate hook

--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -16,12 +16,16 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 	_etl_format = ""
 	_eta_strftime = ""
 	_messages = []
+	_M73 = False
+	_PrusaStyle = False
 	def on_event(self, event, payload):
 		if event == Events.PRINT_STARTED:
 			self._logger.info("Printing started. Detailed progress started.")
 			self._etl_format = self._settings.get(["etl_format"])
 			self._eta_strftime = self._settings.get(["eta_strftime"])
 			self._messages = self._settings.get(["messages"])
+			self._M73 = self._settings.get(["use_M73"])
+			self._PrusaStyle = self._settings.get(["M73_PrusaStyle"])
 			self._repeat_timer = octoprint.util.RepeatedTimer(self._settings.get_int(["time_to_change"]), self.do_work)
 			self._repeat_timer.start()
 		elif event in (Events.PRINT_DONE, Events.PRINT_FAILED, Events.PRINT_CANCELLED):
@@ -46,8 +50,8 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 
 			message = self._get_next_message(currentData)
 			self._printer.commands("M117 {}".format(message))
-			if use_M73:
-				if M73_PrusaStyle:
+			if self._M73:
+				if self._PrusaStyle:
 					printMinutesLeft = int(currentData["progress"]["printTimeLeft"]/60)
 					self._printer.commands("M73 P{}".format(currentData["progress"]["completion"],printMinutesLeft))
 					self._printer.commands("M73 Q{}".format(currentData["progress"]["completion"],printMinutesLeft))

--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -51,12 +51,13 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 			message = self._get_next_message(currentData)
 			self._printer.commands("M117 {}".format(message))
 			if self._M73:
+				progressPerc = int(currentData["progress"]["completion"])
 				if self._PrusaStyle:
 					printMinutesLeft = int(currentData["progress"]["printTimeLeft"]/60)
-					self._printer.commands("M73 P{}".format(currentData["progress"]["completion"],printMinutesLeft))
-					self._printer.commands("M73 Q{}".format(currentData["progress"]["completion"],printMinutesLeft))
+					self._printer.commands("M73 P{} R{}".format(progressPerc,printMinutesLeft))
+					self._printer.commands("M73 Q{} S{}".format(progressPerc,printMinutesLeft))
 				else:
-					self._printer.commands("M73 P{}".format(currentData["progress"]["completion"]))
+					self._printer.commands("M73 P{}".format(progressPerc))
 				
 		except Exception as e:
 			self._logger.info("Caught an exception {0}\nTraceback:{1}".format(e,traceback.format_exc()))


### PR DESCRIPTION
During USB printing from Octoprint, the % and time stay empty on the display of my Prusa i3 MK3. 

I've added configurable support for the M73 (progress) gcode command. This uses the progress field (%) or bar (other printers) of marlin firmware that have this option enabled (e.g. Pursa i3 MK3). 

I've also added an option to send Prusa specific (firmware >= 3.3.0) commands that show the remaining time on the display (see picture).

Documentation is also updated to describe the new settings.

Other separate M73 plugins did not update properly and don't have support for the remaining time of the Prusa firmware, so I decided to add this to detailedprogress myself.

Purse is going to add these commands to slic3r, but that gives a static estimate instead of the dynamic options/plugins we now see from Octoprint.

If you like this addition please merge into the main branch.