### PR TITLE
Also send M73 commands to the print to udpate the status bar on Marlin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ A plugin that sends M117 commands to the printer to display the progress of the 
 ![Example ETL](https://i.imgur.com/oJiMm2p.jpg)
 ![Example Percent](https://i.imgur.com/McaCNsx.jpg)
 
+If the firmware supports the M73 command (Marlin configuration option `LCD_SET_PROGRESS_MANUALLY`), this plugins also updates the progress bar on the display:
+![Example progress bar](https://i.imgur.com/NxD4Pzl.jpg)
+
 ## Setup
 
 Install via the bundled [Plugin Manager](https://github.com/foosel/OctoPrint/wiki/Plugin:-Plugin-Manager)

--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -19,6 +19,7 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 	def on_event(self, event, payload):
 		if event == Events.PRINT_STARTED:
 			self._logger.info("Printing started. Detailed progress started.")
+			self._printer.commands("M73 P0")
 			self._etl_format = self._settings.get(["etl_format"])
 			self._eta_strftime = self._settings.get(["eta_strftime"])
 			self._messages = self._settings.get(["messages"])
@@ -30,6 +31,7 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 				self._repeat_timer = None
 			self._logger.info("Printing stopped. Detailed progress stopped.")
 			self._printer.commands("M117 Print Done")
+			self._printer.commands("M73 P100")
 		elif event == Events.CONNECTED:
 			ip = self._get_host_ip()
 			if not ip:
@@ -46,6 +48,7 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 
 			message = self._get_next_message(currentData)
 			self._printer.commands("M117 {}".format(message))
+			self._printer.commands("M73 P%d" % currentData["progress"]["completion"])
 		except Exception as e:
 			self._logger.info("Caught an exception {0}\nTraceback:{1}".format(e,traceback.format_exc()))
 

--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -19,7 +19,8 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 	def on_event(self, event, payload):
 		if event == Events.PRINT_STARTED:
 			self._logger.info("Printing started. Detailed progress started.")
-			self._printer.commands("M73 P0")
+			if self._settings.get_int(["send_m73"]):
+				self._printer.commands("M73 P0")
 			self._etl_format = self._settings.get(["etl_format"])
 			self._eta_strftime = self._settings.get(["eta_strftime"])
 			self._messages = self._settings.get(["messages"])
@@ -31,7 +32,8 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 				self._repeat_timer = None
 			self._logger.info("Printing stopped. Detailed progress stopped.")
 			self._printer.commands("M117 Print Done")
-			self._printer.commands("M73 P100")
+			if self._settings.get_int(["send_m73"]):
+				self._printer.commands("M73 P100")
 		elif event == Events.CONNECTED:
 			ip = self._get_host_ip()
 			if not ip:
@@ -48,7 +50,8 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 
 			message = self._get_next_message(currentData)
 			self._printer.commands("M117 {}".format(message))
-			self._printer.commands("M73 P%d" % currentData["progress"]["completion"])
+			if self._settings.get_int(["send_m73"]):
+				self._printer.commands("M73 P%d" % currentData["progress"]["completion"])
 		except Exception as e:
 			self._logger.info("Caught an exception {0}\nTraceback:{1}".format(e,traceback.format_exc()))
 
@@ -127,7 +130,8 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 			],
 			eta_strftime = "%H %M %S Day %d",
 			etl_format = "{hours:02d}h{minutes:02d}m{seconds:02d}s",
-			time_to_change = 10
+			time_to_change = 10,
+			send_m73 = True
 		)
 
 	##~~ Softwareupdate hook


### PR DESCRIPTION
In my test Marlin just ignores the M73 if not compiled with support for
them, so this should be safe enough.