### PR TITLE
adds python 3.7 compatibility

### DIFF
--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -147,6 +147,7 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 		)
 
 __plugin_name__ = "Detailed Progress Plugin"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
 	global __plugin_implementation__


### PR DESCRIPTION
I upgraded to Python 3.7 and I could not run your plug-in.

I got the following error: "Plugin Detailed Progress Plugin (0.1.4) is not compatible to Python 3.7.3 (compatibility string: >=2.7,<3)."

So I just added the __plugin_pythoncompat__ information and run this plugin. Now it works like a charm with Python 3.7.3 and I had no issue with my OctoPrint setup.
