### PR TITLE
Pause updates when printer paused, and resume when print resumes.

### DIFF
--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -35,6 +35,16 @@ class DetailedProgressPlugin(octoprint.plugin.EventHandlerPlugin,
 			if not ip:
 				return
 			self._printer.commands("M117 IP {}".format(ip))
+		elif event == Events.PRINT_PAUSED:
+			if self._repeat_timer != None:
+				self._repeat_timer.cancel()
+				self._repeat_timer = None
+			self._logger.info("Printing paused. Detailed progress paused.")
+		elif event == Events.PRINT_RESUMED:
+			self._repeat_timer = octoprint.util.RepeatedTimer(self._settings.get_int(["time_to_change"]), self.do_work)
+			self._repeat_timer.start()
+			self._logger.info("Printing resumed. Detailed progress unpaused.")
+			self._printer.commands("M117 Print Resumed")
 
 	def do_work(self):
 		if not self._printer.is_printing():


### PR DESCRIPTION
Pause updates when printer paused, and resume when print resumes. This is to avoid blobs when resuming after a very long M600 command due to a huge backlog of M117 commands while printer was paused. Please double - no - triple check my work since I am not experienced at all with plugin coding and python.